### PR TITLE
Creates request validator + unit specs

### DIFF
--- a/rswag-specs/lib/rswag/specs/example_helpers.rb
+++ b/rswag-specs/lib/rswag/specs/example_helpers.rb
@@ -2,12 +2,15 @@
 
 require 'rswag/specs/request_factory'
 require 'rswag/specs/response_validator'
+require 'rswag/specs/request_validator'
 
 module Rswag
   module Specs
     module ExampleHelpers
       def submit_request(metadata)
         request = RequestFactory.new.build_request(metadata, self)
+
+        RequestValidator.new.validate!(metadata, request[:payload]) if (200..299).include? metadata[:response][:code]
 
         if RAILS_VERSION < 5
           send(

--- a/rswag-specs/lib/rswag/specs/request_validator.rb
+++ b/rswag-specs/lib/rswag/specs/request_validator.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'active_support/core_ext/hash/slice'
+require 'json-schema'
+require 'json'
+require 'rswag/specs/extended_schema'
+
+module Rswag
+  module Specs
+    class RequestValidator
+      def initialize(config = ::Rswag::Specs.config)
+        @config = config
+      end
+
+      def validate!(metadata, request_payload)
+        swagger_doc = @config.get_openapi_spec(metadata[:openapi_spec] || metadata[:swagger_doc])
+
+        validate_body!(metadata, swagger_doc, request_payload)
+      end
+
+      private
+
+      def validate_body!(metadata, swagger_doc, body)
+        # Finding the first one for now, but need to see what happens if we
+        # have more than one.
+        body_parameter = metadata[:operation][:parameters].find { |p| p[:in] == :body }
+        request_schema = body_parameter[:schema] if body_parameter
+
+        return if request_schema.nil?
+
+        version = @config.get_openapi_spec_version(metadata[:openapi_spec] || metadata[:swagger_doc])
+        schemas = definitions_or_component_schemas(swagger_doc, version)
+
+        validation_schema = request_schema
+                            .merge('$schema' => 'http://tempuri.org/rswag/specs/extended_schema')
+                            .merge(schemas)
+
+        validation_options = validation_options_from(metadata)
+
+        errors = JSON::Validator.fully_validate(validation_schema, body, validation_options)
+        return unless errors.any?
+
+        raise UnexpectedRequest,
+              "Expected request body to match schema: #{errors.join("\n")}\n" \
+              "Request body: #{JSON.pretty_generate(JSON.parse(body))}"
+      end
+
+      def validation_options_from(metadata)
+        is_strict = @config.openapi_strict_schema_validation
+
+        if metadata.key?(:swagger_strict_schema_validation)
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
+          is_strict = !!metadata[:swagger_strict_schema_validation]
+        elsif metadata.key?(:openapi_strict_schema_validation)
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: This option will be removed in v3.0 please use openapi_all_properties_required and openapi_no_additional_properties set to true')
+          is_strict = !!metadata[:openapi_strict_schema_validation]
+        end
+
+        all_properties_required = metadata.fetch(:openapi_all_properties_required,
+                                                 @config.openapi_all_properties_required)
+        no_additional_properties = metadata.fetch(:openapi_no_additional_properties,
+                                                  @config.openapi_no_additional_properties)
+
+        {
+          strict: is_strict,
+          allPropertiesRequired: all_properties_required,
+          noAdditionalProperties: no_additional_properties
+        }
+      end
+
+      def definitions_or_component_schemas(swagger_doc, version)
+        if version.start_with?('2')
+          swagger_doc.slice(:definitions)
+        elsif swagger_doc.key?(:definitions) # Openapi3
+          Rswag::Specs.deprecator.warn('Rswag::Specs: WARNING: definitions is replaced in OpenAPI3! Rename to components/schemas (in swagger_helper.rb)')
+          swagger_doc.slice(:definitions)
+        else
+          components = swagger_doc[:components] || {}
+          { components: components }
+        end
+      end
+    end
+
+    class UnexpectedRequest < StandardError; end
+  end
+end

--- a/rswag-specs/spec/rswag/specs/request_validator_spec.rb
+++ b/rswag-specs/spec/rswag/specs/request_validator_spec.rb
@@ -1,0 +1,828 @@
+# frozen_string_literal: true
+
+require 'rswag/specs/request_validator'
+
+module Rswag
+  module Specs
+    RSpec.describe RequestValidator do
+      subject { RequestValidator.new(config) }
+
+      before do
+        allow(config).to receive(:get_openapi_spec).and_return(openapi_spec)
+        allow(config).to receive(:get_openapi_spec_version).and_return('2.0')
+        allow(config).to receive(:openapi_strict_schema_validation).and_return(openapi_strict_schema_validation)
+        allow(config).to receive(:openapi_all_properties_required).and_return(openapi_all_properties_required)
+        allow(config).to receive(:openapi_no_additional_properties).and_return(openapi_no_additional_properties)
+      end
+
+      let(:config) { double('config') }
+      let(:openapi_spec) { {} }
+      let(:example) { double('example') }
+      let(:openapi_strict_schema_validation) { false }
+      let(:openapi_all_properties_required) { false }
+      let(:openapi_no_additional_properties) { false }
+      let(:schema) do
+        {
+          type: :object,
+          properties: {
+            text: { type: :string },
+            number: { type: :integer }
+          },
+          required: %w[text number]
+        }
+      end
+
+      let(:metadata) do
+        {
+          operation: {
+            parameters: [{
+              in: :body,
+              schema: { **schema }
+            }]
+          }
+        }
+      end
+
+      shared_context 'with strict deprecation warning' do
+        before do
+          allow(Rswag::Specs.deprecator).to receive(:warn)
+        end
+
+        after do
+          expect(Rswag::Specs.deprecator)
+            .to have_received(:warn).with('Rswag::Specs: WARNING: This option will be removed in v3.0' \
+                                          ' please use openapi_all_properties_required' \
+                                          ' and openapi_no_additional_properties set to true')
+        end
+      end
+
+      describe '#validate!(metadata, request)' do
+        let(:call) { subject.validate!(metadata, request_payload) }
+        let(:request_payload) { '{"text":"Some comment", "number": 3}' }
+
+        context 'request matches metadata' do
+          it { expect { call }.to_not raise_error }
+        end
+
+        context 'request body differs from metadata' do
+          let(:request_payload) { '{"foo":"Some comment"}' }
+          it { expect { call }.to raise_error(/Expected request body/) }
+        end
+
+        context 'when request body does not have additional properties and missing properties' do
+          context 'with strict schema validation enabled' do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with strict schema validation disabled' do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with strict schema validation disabled in config but enabled in metadata' do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with strict schema validation enabled in config but disabled in metadata' do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled in config but enabled in metadata' do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled in config but disabled in metadata' do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties validation disabled in config but enabled in metadata' do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties validation enabled in config but disabled in metadata' do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context 'with strict schema validation enabled' do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with strict schema validation disabled' do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with strict schema validation disabled in config but enabled in metadata' do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with strict schema validation enabled in config but disabled in metadata' do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled in config but enabled in metadata' do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled in config but disabled in metadata' do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties validation disabled in config but enabled in metadata' do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties validation enabled in config but disabled in metadata' do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+          end
+        end
+
+        context 'when request body has additional properties' do
+          let(:request_payload) { '{"foo":"Some comment", "number": 3, "text":"bar"}' }
+
+          context 'with strict schema validation enabled' do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation disabled' do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with strict schema validation disabled in config but enabled in metadata' do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation enabled in config but disabled in metadata' do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required disabled in config but enabled in metadata' do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with all properties required enabled in config but disabled in metadata' do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'with no additional properties validation disabled in config but enabled in metadata' do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties validation enabled in config but disabled in metadata' do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.not_to raise_error }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context 'with strict schema validation enabled' do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with strict schema validation disabled' do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with strict schema validation disabled in config but enabled in metadata' do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with strict schema validation enabled in config but disabled in metadata' do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled in config but enabled in metadata' do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled in config but disabled in metadata' do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties validation disabled in config but enabled in metadata' do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with no additional properties validation enabled in config but disabled in metadata' do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+          end
+        end
+
+        context 'when request body has missing properties' do
+          let(:request_payload) { '{"number": 3}' }
+
+          context 'with strict schema validation enabled' do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation disabled' do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation disabled in config but enabled in metadata' do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation enabled in config but disabled in metadata' do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required disabled in config but enabled in metadata' do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required enabled in config but disabled in metadata' do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties validation disabled in config but enabled in metadata' do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties validation enabled in config but disabled in metadata' do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+        end
+
+        context 'when request body has missing properties and additional properties' do
+          let(:request_payload) { '{"foo":"Some comment", "text":"bar"}' }
+
+          context 'with strict schema validation enabled' do
+            let(:openapi_strict_schema_validation) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation disabled' do
+            let(:openapi_strict_schema_validation) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation disabled in config but enabled in metadata' do
+            let(:openapi_strict_schema_validation) { false }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with strict schema validation enabled in config but disabled in metadata' do
+            let(:openapi_strict_schema_validation) { true }
+            let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+            include_context 'with strict deprecation warning'
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required enabled' do
+            let(:openapi_all_properties_required) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required disabled' do
+            let(:openapi_all_properties_required) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required disabled in config but enabled in metadata' do
+            let(:openapi_all_properties_required) { false }
+            let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with all properties required enabled in config but disabled in metadata' do
+            let(:openapi_all_properties_required) { true }
+            let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties enabled' do
+            let(:openapi_no_additional_properties) { true }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties disabled' do
+            let(:openapi_no_additional_properties) { false }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties validation disabled in config but enabled in metadata' do
+            let(:openapi_no_additional_properties) { false }
+            let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'with no additional properties validation enabled in config but disabled in metadata' do
+            let(:openapi_no_additional_properties) { true }
+            let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+            it { expect { call }.to raise_error(/Expected request body/) }
+          end
+
+          context 'when schema does not have required property' do
+            let(:schema) do
+              {
+                type: :object,
+                properties: {
+                  text: { type: :string },
+                  number: { type: :integer }
+                }
+              }
+            end
+
+            context 'with strict schema validation enabled' do
+              let(:openapi_strict_schema_validation) { true }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with strict schema validation disabled' do
+              let(:openapi_strict_schema_validation) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with strict schema validation disabled in config but enabled in metadata' do
+              let(:openapi_strict_schema_validation) { false }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: true) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with strict schema validation enabled in config but disabled in metadata' do
+              let(:openapi_strict_schema_validation) { true }
+              let(:metadata) { super().merge(openapi_strict_schema_validation: false) }
+
+              include_context 'with strict deprecation warning'
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required enabled' do
+              let(:openapi_all_properties_required) { true }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with all properties required disabled' do
+              let(:openapi_all_properties_required) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with all properties required disabled in config but enabled in metadata' do
+              let(:openapi_all_properties_required) { false }
+              let(:metadata) { super().merge(openapi_all_properties_required: true) }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with all properties required enabled in config but disabled in metadata' do
+              let(:openapi_all_properties_required) { true }
+              let(:metadata) { super().merge(openapi_all_properties_required: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties enabled' do
+              let(:openapi_no_additional_properties) { true }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with no additional properties disabled' do
+              let(:openapi_no_additional_properties) { false }
+
+              it { expect { call }.not_to raise_error }
+            end
+
+            context 'with no additional properties validation disabled in config but enabled in metadata' do
+              let(:openapi_no_additional_properties) { false }
+              let(:metadata) { super().merge(openapi_no_additional_properties: true) }
+
+              it { expect { call }.to raise_error(/Expected request body/) }
+            end
+
+            context 'with no additional properties validation enabled in config but disabled in metadata' do
+              let(:openapi_no_additional_properties) { true }
+              let(:metadata) { super().merge(openapi_no_additional_properties: false) }
+
+              it { expect { call }.not_to raise_error }
+            end
+          end
+        end
+
+        context 'referenced schemas' do
+          context 'swagger 2.0' do
+            before do
+              openapi_spec[:definitions] = {
+                'blog' => {
+                  type: :object,
+                  properties: { foo: { type: :string } },
+                  required: ['foo']
+                }
+              }
+            end
+
+            let(:schema) { { '$ref' => '#/definitions/blog' } }
+
+            it 'uses the referenced schema to validate the request body' do
+              expect { call }.to raise_error(/Expected request body/)
+            end
+          end
+
+          context 'openapi 3.0.1' do
+            context 'components/schemas' do
+              before do
+                allow(Rswag::Specs.deprecator).to receive(:warn)
+                allow(config).to receive(:get_openapi_spec_version).and_return('3.0.1')
+                openapi_spec[:components] = {
+                  schemas: {
+                    'blog' => {
+                      type: :object,
+                      properties: { foo: { type: :string } },
+                      required: ['foo']
+                    }
+                  }
+                }
+              end
+
+              let(:schema) { { '$ref' => '#/components/schemas/blog' } }
+
+              it 'uses the referenced schema to validate the request body' do
+                expect { call }.to raise_error(/Expected request body/)
+              end
+
+              context 'nullable referenced schema' do
+                let(:request_payload) { '{ "blog": null }' }
+                let(:schema) do
+                  {
+                    properties: { blog: { '$ref' => '#/components/schema/blog' } },
+                    required: ['blog']
+                  }
+                end
+
+                context 'using x-nullable attribute' do
+                  before do
+                    schema[:properties][:blog]['x-nullable'] = true
+                  end
+
+                  context 'request matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+
+                context 'using nullable attribute' do
+                  before do
+                    schema[:properties][:blog]['nullable'] = true
+                  end
+
+                  context 'request matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+              end
+
+              context 'nullable oneOf with referenced schema' do
+                let(:request_payload) { '{ "blog": null }' }
+                let(:schema) do
+                  {
+                    properties: {
+                      blog: {
+                        oneOf: [{ '$ref' => '#/components/schema/blog' }]
+                      }
+                    },
+                    required: ['blog']
+                  }
+                end
+
+                context 'using x-nullable attribute' do
+                  before do
+                    schema[:properties][:blog]['x-nullable'] = true
+                  end
+
+                  context 'request matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+
+                context 'using nullable attribute' do
+                  before do
+                    schema[:properties][:blog]['nullable'] = true
+                  end
+
+                  context 'request matches metadata' do
+                    it { expect { call }.to_not raise_error }
+                  end
+                end
+              end
+            end
+
+            context 'deprecated definitions' do
+              before do
+                allow(Rswag::Specs.deprecator).to receive(:warn)
+                allow(config).to receive(:get_openapi_spec_version).and_return('3.0.1')
+                openapi_spec[:definitions] = {
+                  'blog' => {
+                    type: :object,
+                    properties: { foo: { type: :string } },
+                    required: ['foo']
+                  }
+                }
+              end
+
+              let(:schema) { { '$ref' => '#/definitions/blog' } }
+
+              it 'warns the user to upgrade' do
+                expect { call }.to raise_error(/Expected request body/)
+                expect(Rswag::Specs.deprecator).to have_received(:warn)
+                  .with('Rswag::Specs: WARNING: definitions is replaced in OpenAPI3! Rename to components/schemas (in swagger_helper.rb)')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Problem
There are multiple open issues requesting that rswag validate incoming parameters (i.e. [here](https://github.com/rswag/rswag/issues/568) and [here](https://github.com/rswag/rswag/issues/435#issuecomment-1051609781)). 

## Solution
A clear and concise description of what the solution is.

### This concerns this parts of the OpenAPI Specification:
* [EXAMPLE_LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#data-types)
* [ANOTHER LINK TO RELEVANT OPEN API SPECS PAGE](https://spec.openapis.org/oas/v3.1.0#schema)

### The changes I made are compatible with:
- [ ] OAS2
- [ ] OAS3
- [ ] OAS3.1

### Related Issues
Links to any related issues.

### Checklist
- [ ] Added tests
- [ ] Changelog updated
- [ ] Added documentation to README.md
- [ ] Added example of using the enhancement into [test-app](https://github.com/rswag/rswag/tree/master/test-app)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
